### PR TITLE
feat: enable dynamodb streams on cases table

### DIFF
--- a/services/dynamos/cases/serverless.yml
+++ b/services/dynamos/cases/serverless.yml
@@ -37,3 +37,11 @@ resources:
           - Arn
       Export:
         Name: ${self:custom.stage}-CasesTableArn
+
+    CasesTableStreamArn:
+      Value:
+        Fn::GetAtt:
+          - CasesTable
+          - StreamArn
+      Export:
+        Name: ${self:custom.stage}-CasesTableStreamArn

--- a/services/dynamos/cases/serverless.yml
+++ b/services/dynamos/cases/serverless.yml
@@ -26,6 +26,8 @@ resources:
           - AttributeName: SK
             KeyType: RANGE
         BillingMode: PAY_PER_REQUEST
+        StreamSpecification:
+          StreamViewType: NEW_IMAGE
 
   Outputs:
     CasesTableArn:


### PR DESCRIPTION
Enabling DynamoDb streams on the cases table so that we can trigger lambdas based on changes made in the table.