### PR TITLE
Feat/attachments bucket resource

### DIFF
--- a/services/attachments/serverless.yml
+++ b/services/attachments/serverless.yml
@@ -1,4 +1,4 @@
-service: hbg-s3-attachments
+service: hbg-attachments-s3
 
 custom: ${file(../../serverless.common.yml):custom}
 
@@ -9,10 +9,21 @@ provider:
 
 resources:
   Resources:
-    AttachementsBucket:
+    AttachmentsBucketArn:
       Type: AWS::S3::Bucket
       Properties:
-        BucketName: hbg-attachments
+        BucketName: !Join
+          - "-"
+          - - "hbg-attachments"
+            - !Select
+              - 0
+              - !Split
+                - "-"
+                - !Select
+                  - 2
+                  - !Split
+                    - "/"
+                    - !Ref "AWS::StackId"
         AccessControl: PublicRead
         CorsConfiguration:
           CorsRules:
@@ -27,10 +38,16 @@ resources:
                 - "*"
 
   Outputs:
-    AttachementsBucketArn:
+    AttachmentsBucketArn:
       Value:
         Fn::GetAtt:
-          - AttachementsBucket
+          - AttachmentsBucketArn
           - Arn
       Export:
-        Name: ${self:custom.stage}-AttachementsBucketArn
+        Name: ${self:custom.stage}-AttachmentsBucketArn
+
+    AttachmentsBucketName:
+      Value: !Ref AttachmentsBucketArn
+
+      Export:
+        Name: ${self:custom.stage}-AttachmentsBucketName

--- a/services/attachments/serverless.yml
+++ b/services/attachments/serverless.yml
@@ -1,0 +1,36 @@
+service: hbg-s3-attachments
+
+custom: ${file(../../serverless.common.yml):custom}
+
+provider:
+  name: aws
+  stage: dev
+  region: eu-north-1
+
+resources:
+  Resources:
+    AttachementsBucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: hbg-attachments
+        AccessControl: PublicRead
+        CorsConfiguration:
+          CorsRules:
+            - AllowedMethods:
+                - GET
+                - PUT
+                - POST
+                - HEAD
+              AllowedOrigins:
+                - "*"
+              AllowedHeaders:
+                - "*"
+
+  Outputs:
+    AttachementsBucketArn:
+      Value:
+        Fn::GetAtt:
+          - AttachementsBucket
+          - Arn
+      Export:
+        Name: ${self:custom.stage}-AttachementsBucketArn


### PR DESCRIPTION
This PR adds a new resource to AWS that will create a bucket where uploaded user files will be stored.

Test This PR:

1. Deploy the resource from within the path services/attachments by running:  sls deploy
2. After deployment make sure the resource can be found in the AWS Management Console on aws.amazon.com