### PR TITLE
Feat/pdf templates s3

### DIFF
--- a/services/pdfTemplates/serverless.yml
+++ b/services/pdfTemplates/serverless.yml
@@ -6,6 +6,12 @@ provider:
   name: aws
   stage: dev
   region: eu-north-1
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - s3:GetObject
+      Resource:
+        - !Ref PdfTemplatesBucketArn
 
 resources:
   Resources:
@@ -14,7 +20,7 @@ resources:
       Properties:
         BucketName: !Join
           - "-"
-          - - "pdf-templates-s3"
+          - - "pdf-case-templates-s3"
             - !Select
               - 0
               - !Split

--- a/services/pdfTemplates/serverless.yml
+++ b/services/pdfTemplates/serverless.yml
@@ -1,0 +1,53 @@
+service: pdfTemplates-s3
+
+custom: ${file(../../serverless.common.yml):custom}
+
+provider:
+  name: aws
+  stage: dev
+  region: eu-north-1
+
+resources:
+  Resources:
+    PdfTemplatesBucketArn:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: !Join
+          - "-"
+          - - "pdf-templates-s3"
+            - !Select
+              - 0
+              - !Split
+                - "-"
+                - !Select
+                  - 2
+                  - !Split
+                    - "/"
+                    - !Ref "AWS::StackId"
+        AccessControl: PublicRead
+        CorsConfiguration:
+          CorsRules:
+            - AllowedMethods:
+                - GET
+                - PUT
+                - POST
+                - HEAD
+              AllowedOrigins:
+                - "*"
+              AllowedHeaders:
+                - "*"
+
+  Outputs:
+    PdfTemplatesBucketArn:
+      Value:
+        Fn::GetAtt:
+          - PdfTemplatesBucketArn
+          - Arn
+      Export:
+        Name: ${self:custom.stage}-PdfTemplatesBucketArn
+
+    PdfTemplatesBucketName:
+      Value: !Ref PdfTemplatesBucketArn
+
+      Export:
+        Name: ${self:custom.stage}-PdfTemplatesBucketName

--- a/services/pdfTemplates/serverless.yml
+++ b/services/pdfTemplates/serverless.yml
@@ -6,12 +6,6 @@ provider:
   name: aws
   stage: dev
   region: eu-north-1
-  iamRoleStatements:
-    - Effect: Allow
-      Action:
-        - s3:GetObject
-      Resource:
-        - !Ref PdfTemplatesBucketArn
 
 resources:
   Resources:


### PR DESCRIPTION
Adds a S3 bucket resource for storing the templates we need for generating pdfs.

Reuses the logic from the attachment bucket to generate a unique bucket name, which is then exported as ${self:custom.stage}-PdfTemplatesBucketName. One can then import this name and use that to refer to the bucket. 
