### PR TITLE
feat(case-db): add global secondary index used by pdf-ms

### DIFF
--- a/services/dynamos/cases/serverless.yml
+++ b/services/dynamos/cases/serverless.yml
@@ -20,6 +20,8 @@ resources:
             AttributeType: S
           - AttributeName: SK
             AttributeType: S
+          - AttributeName: formId
+            AttributeType: S
         KeySchema:
           - AttributeName: PK
             KeyType: HASH
@@ -28,6 +30,24 @@ resources:
         BillingMode: PAY_PER_REQUEST
         StreamSpecification:
           StreamViewType: NEW_IMAGE
+        GlobalSecondaryIndexes:
+          - IndexName: PK-formId-gsi
+            KeySchema: 
+              - AttributeName: PK
+                KeyType: HASH
+              - AttributeName: formId
+                KeyType: RANGE
+            Projection:
+              NonKeyAttributes:
+                - answers
+                - details
+                - SK
+                - updatedAt
+                - createdAt
+                - id 
+                - provider
+                - status
+              ProjectionType: INCLUDE
 
   Outputs:
     CasesTableArn:


### PR DESCRIPTION
Adds a global secondary index (gsi) for querying the cases-db to find all relevant cases, that is, all cases belonging to a certain user which also share the same formId. This also projects out the relevant properties, most notably we want the status, various timestamps, answers, details but we don't want the saved pdf (since this is large). 

Note: for me, deploying this once works, but if you change anything and redeploy, then it doesn't work and CloudFormation becomes unhappy. It's apparently tricky to make changes to gsi's through cloudFormation, but it works just fine to change them from the web console interface. 