### PR TITLE
chore(ssm): added ssm params for case envs

### DIFF
--- a/services/parameterStore/envs/example.caseEnvs.json
+++ b/services/parameterStore/envs/example.caseEnvs.json
@@ -1,0 +1,3 @@
+{
+    "recurringFormId": "some_form_id"
+}


### PR DESCRIPTION
## Explain the changes you’ve made
Added a new boilerplate for case ssm parameters.

## Explain why these changes are made
The formId of a case needs to be stored in order to be accessed by other AWS services. Since every AWS environment has it's own forms dynamo the id will never be the same and therefore a dynamic way of setting this is needed. 

## Explain your solution
Added a new boilerplate file for caseEnvs that can be updated using a bash script.

## How to test the changes?
1. Checkout this branch
2. Copy the file example.caseEnvs.json and change the name to caseEnvs.json.
3. Change the value of the key recurringFormId to a valid formId
4. Run the bash script ssmPutParamters.sh to create the new parameter in AWS.
5. Open the AWS console and make sure the parameter exists in Systems Manager -> Parameter Store.


## Was this feature tested in the following environments?
- [x] Personal AWS Environment.
