### PR TITLE
Updated case ssm params to be viva specific in order to accomodate changes in api repo

### DIFF
--- a/services/parameterStore/envs/example.caseEnvs.json
+++ b/services/parameterStore/envs/example.caseEnvs.json
@@ -1,3 +1,0 @@
-{
-    "recurringFormId": "some_form_id"
-}

--- a/services/parameterStore/envs/example.vivaCaseEnvs.json
+++ b/services/parameterStore/envs/example.vivaCaseEnvs.json
@@ -1,4 +1,4 @@
 {
-    "recurringFormId": "some_form_id",
-    "completionFormId": "a_form_id"
+  "recurringFormId": "some_form_id",
+  "completionFormId": "a_form_id"
 }

--- a/services/parameterStore/envs/example.vivaCaseEnvs.json
+++ b/services/parameterStore/envs/example.vivaCaseEnvs.json
@@ -1,0 +1,4 @@
+{
+    "recurringFormId": "some_form_id",
+    "completionFormId": "a_form_id"
+}


### PR DESCRIPTION
The example file for caseEnvs have been renamed to vivaCaseEnvs to accomdate changes in the way ssm params are used in the viva-ms. In addition to the name changed a new value have been added "completionFormId", this is to set the id of the form responsible for the completion process during an EKB application.