### PR TITLE
feat: enable cmk encryption cu-g31d9m

### DIFF
--- a/services/dynamos/cases/serverless.yml
+++ b/services/dynamos/cases/serverless.yml
@@ -30,6 +30,10 @@ resources:
         BillingMode: PAY_PER_REQUEST
         StreamSpecification:
           StreamViewType: NEW_IMAGE
+        SSESpecification:
+          KMSMasterKeyId: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/external/master
+          SSEEnabled: true
+          SSEType: KMS
         GlobalSecondaryIndexes:
           - IndexName: PK-formId-gsi
             KeySchema: 

--- a/services/dynamos/forms/serverless.yml
+++ b/services/dynamos/forms/serverless.yml
@@ -22,10 +22,6 @@ resources:
           - AttributeName: PK
             KeyType: HASH
         BillingMode: PAY_PER_REQUEST
-        SSESpecification:
-          KMSMasterKeyId: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/external/master
-          SSEEnabled: true
-          SSEType: KMS
 
   Outputs:
     FormsTableArn:

--- a/services/dynamos/forms/serverless.yml
+++ b/services/dynamos/forms/serverless.yml
@@ -22,6 +22,10 @@ resources:
           - AttributeName: PK
             KeyType: HASH
         BillingMode: PAY_PER_REQUEST
+        SSESpecification:
+          KMSMasterKeyId: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/external/master
+          SSEEnabled: true
+          SSEType: KMS
 
   Outputs:
     FormsTableArn:

--- a/services/dynamos/users/serverless.yml
+++ b/services/dynamos/users/serverless.yml
@@ -22,6 +22,10 @@ resources:
           - AttributeName: personalNumber
             KeyType: HASH
         BillingMode: PAY_PER_REQUEST
+        SSESpecification:
+          KMSMasterKeyId: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/external/master
+          SSEEnabled: true
+          SSEType: KMS
 
   Outputs:
     UsersTableArn:


### PR DESCRIPTION
## Feature description
This enables the usage of CMK in KMS

## Solution description
The ARN for a custom made CMK added to casses and users dynamodb table.

## What areas is affected by these changes?.
Infrastructure.

## Is there any existing behavior change of other features due to this code change?
Yes this will BREAK your AWS environment if you have not generated a CMK key for AWS KMS.
Guide for this is added in this PR
https://github.com/helsingborg-stad/helsingborg-io-sls-resources/pull/49

## Was this feature tested in the following environments?
- [x] Your personal AWS environment.
- [ ] Your local Serverless environment.
