### PR TITLE
feat: enable cmk encryption on s3 cu-g31d9m

### DIFF
--- a/services/attachments/serverless.yml
+++ b/services/attachments/serverless.yml
@@ -24,6 +24,12 @@ resources:
                   - !Split
                     - "/"
                     - !Ref "AWS::StackId"
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: 'aws:kms'
+                KMSMasterKeyID: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/external/master
+              BucketKeyEnabled: true
         AccessControl: PublicRead
         CorsConfiguration:
           CorsRules:


### PR DESCRIPTION
## Feature description
This enables the usage of CMK in KMS

## Solution description
The ARN for a custom made CMK added to s3 bucket attachments

## What areas is affected by these changes?.
Infrastructure.

## Is there any existing behavior change of other features due to this code change?
Yes this will BREAK your AWS environment if you have not generated a CMK key for AWS KMS.
Guide for this is added in this PR
https://github.com/helsingborg-stad/helsingborg-io-sls-resources/pull/49

## Was this feature tested in the following environments?
- [x] Your personal AWS environment.
- [ ] Your local Serverless environment.