### PR TITLE
🐛 Fix issue with the cases table in DynamoDB not having a TTL key set

### DIFF
--- a/services/dynamos/cases/serverless.yml
+++ b/services/dynamos/cases/serverless.yml
@@ -28,6 +28,9 @@ resources:
           - AttributeName: SK
             KeyType: RANGE
         BillingMode: PAY_PER_REQUEST
+        TimeToLiveSpecification:
+          AttributeName: expirationTime
+          Enabled: true
         StreamSpecification:
           StreamViewType: NEW_IMAGE
         GlobalSecondaryIndexes:


### PR DESCRIPTION
With the help of @yo-l1982

## Feature description

Fixes the issue of the cases table not having a TTL key set.

## Solution description
Describe your code changes in a more technical detailed for reviewers.

Adding the `TimeToLiveSpecification` key to `serverless.yml` allows us to enable the `expirationTime` attribute as the TTL key.

## What areas is affected by these changes?.

DynamoDB cases expiry.

## Is there any existing behavior change of other features due to this code change?

No

## Is your code structured in a way so that reviewers can understand it?

Yes

## Was this feature tested in the following environments?
- [x] Your personal AWS environment.
- [] Your local serverless environment.