### PR TITLE
Add web application firewall with ip block and some free subscriptions of bad guy blockers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,6 @@ env.yml
 # stuff
 .DS_Store
 .vscode
+.dccache 
 
 [!example.]*.json

--- a/services/gateway/root/serverless.yml
+++ b/services/gateway/root/serverless.yml
@@ -29,6 +29,89 @@ functions:
           cors: true
 
 resources:
+  Resources:
+    WAFv2WebACL:
+      Type: AWS::WAFv2::WebACL
+      Properties:
+        Name: WebACL-gateway-root-${self:custom.stage}
+        Scope: REGIONAL
+        Description: WebACL for API Gateway
+        DefaultAction:
+          Allow: {}
+        VisibilityConfig:
+          SampledRequestsEnabled: true
+          CloudWatchMetricsEnabled: true
+          MetricName: WebACL-gateway-root-${self:custom.stage}
+        Rules:
+          - Name: BlockIPs
+            Priority: 0
+            Action:
+              Block: {}
+            VisibilityConfig:
+              SampledRequestsEnabled: true
+              CloudWatchMetricsEnabled: true
+              MetricName: WAF-BlockIPs
+            Statement:
+              IPSetReferenceStatement:
+                Arn: !GetAtt WAFv2IPSetBlocked.Arn
+          - Name: AWS-AWSManagedRulesAmazonIpReputationList
+            Priority: 1
+            OverrideAction:
+              None: {}
+            VisibilityConfig:
+              SampledRequestsEnabled: true
+              CloudWatchMetricsEnabled: true
+              MetricName: WAF-RuleWithAWSManagedRulesMetric
+            Statement:
+              ManagedRuleGroupStatement:
+                VendorName: AWS
+                Name: AWSManagedRulesAmazonIpReputationList
+                ExcludedRules: []
+          - Name: AWS-AWSManagedRulesKnownBadInputsRuleSet
+            Priority: 2
+            OverrideAction:
+              None: {}
+            VisibilityConfig:
+              SampledRequestsEnabled: true
+              CloudWatchMetricsEnabled: true
+              MetricName: WAF-RuleWithAWSManagedRulesMetric
+            Statement:
+              ManagedRuleGroupStatement:
+                VendorName: AWS
+                Name: AWSManagedRulesKnownBadInputsRuleSet
+                ExcludedRules: []
+
+          # - Name: AWS-AWSManagedRulesBotControlRuleSet  # Commented for now because of cost considerations.
+          #   Priority: 3
+          #   OverrideAction:
+          #     None: {}
+          #   VisibilityConfig:
+          #     SampledRequestsEnabled: true
+          #     CloudWatchMetricsEnabled: true
+          #     MetricName: WAF-AWSManagedRulesBotControlRuleSet
+          #   Statement:
+          #     ManagedRuleGroupStatement:
+          #       VendorName: AWS
+          #       Name: AWSManagedRulesBotControlRuleSet
+          #       ExcludedRules: []
+
+    WAFv2IPSetBlocked:
+      Type: AWS::WAFv2::IPSet
+      Properties:
+        Description: Ips that are blocked from the API Gateway
+        Name: BlockedIPs
+        Scope: REGIONAL
+        IPAddressVersion: IPV4
+        Addresses:
+          - 1.2.1.1/32  # Example ip.
+
+
+    WAFv2WebACLAssociation:
+      Type: AWS::WAFv2::WebACLAssociation
+      Properties: 
+        ResourceArn:  !Sub "arn:aws:apigateway:${self:provider.region}::/restapis/${ApiGatewayRestApi}/stages/${self:custom.stage}"
+        WebACLArn: !GetAtt WAFv2WebACL.Arn
+
   Outputs:
     ApiGatewayRestApiId:
       Value:


### PR DESCRIPTION
## Feature description
This will add AWS WAF firewall and connect it to our API Gateway.
Added to this update is:

- Example IP block.
- Two subscriptions to AWS rulesets that are made to filter out bad inputs and bad reputation ip numbers(i.e ips that are known sources of attacks.)
- A commented rule(For now to keep costs down) with Bot Control for blocking bots.  https://aws.amazon.com/waf/features/bot-control/

## Solution description
Fully AWS Managed service in Cloudformation format

## What areas is affected by these changes?.
None.

## Is there any excisting behavior change of other features due to this code change?
No this hooks right in with no downtime on deploy.

## Are your code strutured in a way so that reviewers can understand it?
Everybody understands CFN right?

## Was this feature tested in the following environments?
- [x] Your personal AWS environment.
- [ ] Your local serverless enviorment.
