### PR TITLE
feat: add booking api gateway resource

### DIFF
--- a/services/gateway/resources/booking/serverless.yml
+++ b/services/gateway/resources/booking/serverless.yml
@@ -1,0 +1,29 @@
+service: booking-gateway-resource
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stage: ${opt:stage, 'dev'}
+  region: eu-north-1
+
+  apiGateway:
+    restApiId:
+      !ImportValue ${self:provider.stage}-ExtApiGatewayRestApiId
+    restApiRootResourceId:
+      !ImportValue ${self:provider.stage}-ExtApiGatewayRestApiRootResourceId
+
+resources:
+  Resources:
+    ApiGatewayResourceBooking:
+      Type: AWS::ApiGateway::Resource
+      Properties:
+        RestApiId: ${self:provider.apiGateway.restApiId}
+        ParentId: ${self:provider.apiGateway.restApiRootResourceId}
+        PathPart: booking
+
+  Outputs:
+    ApiGatewayResourceBooking:
+      Value: !Ref ApiGatewayResourceBooking
+      Export:
+        Name: ${self:provider.stage}-ExtApiGatewayResourceBooking
+


### PR DESCRIPTION
## What was solved
Adding "booking" as a new Api Gateway resource path which should be used when using the booking-api service.

## How was it solved
Created a new serverless stack called `booking-gateway-resource` which creates the new api gateway resource to the root api gateway.

## Why was it solved in this way
This is the agreed way of creating Api Gateway resources for the root Api Gateway.

## How was it tested
Tested by first deploying the root Api Gateway (gateway-root) serverless stack and thereafter deploying the new resource. Checked the Api Gateway console and verified that the new resource were attached to the root gateway.