### PR TITLE
feat: add SSM parameters for outlook search

### DIFF
--- a/services/parameterStore/envs/example.bookingEnvs.json
+++ b/services/parameterStore/envs/example.bookingEnvs.json
@@ -1,5 +1,4 @@
 {
   "outlookBookingEndpoint": "datatorget_outlook_booking_endpoint",
-  "apiKey": "datatorget_api_key",
-  "outlookSearchUrl": "datatorget_outlook_search_endpoint"
+  "apiKey": "datatorget_api_key"
 }

--- a/services/parameterStore/envs/example.searchEnvs.json
+++ b/services/parameterStore/envs/example.searchEnvs.json
@@ -1,0 +1,4 @@
+{
+    "outlookSearchEndpoint": "datatorget_outlook_search_endpoint",
+    "apiKey": "datatorget_api_key"
+}


### PR DESCRIPTION
## What was solved
Store search env values in AWS SSM Parameterstore when deploying

## How was it solved
Solved it by adding example.searchEnvs.json file to the parameterStore/envs folder

## Why was it solved in this way
This is whats agreed upon storing env variables

## How was it tested
Tested deploying it in my sandbox environment and checked the AWS SSM console for the correct values stored in the .json file