### PR TITLE
feat: add api gateway resource for bookables

### DIFF
--- a/services/gateway/resources/bookables/serverless.yml
+++ b/services/gateway/resources/bookables/serverless.yml
@@ -1,0 +1,30 @@
+service: bookables-gateway-resource
+
+custom: ${file(../../../../serverless.common.yml):custom}
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stage: dev
+  region: eu-north-1
+
+  apiGateway:
+    restApiId:
+      !ImportValue ${self:custom.stage}-ExtApiGatewayRestApiId
+    restApiRootResourceId:
+      !ImportValue ${self:custom.stage}-ExtApiGatewayRestApiRootResourceId
+
+resources:
+  Resources:
+    ApiGatewayResourceBookables:
+      Type: AWS::ApiGateway::Resource
+      Properties:
+        RestApiId: ${self:provider.apiGateway.restApiId}
+        ParentId: ${self:provider.apiGateway.restApiRootResourceId}
+        PathPart: bookables
+
+  Outputs:
+    ApiGatewayResourceBookables:
+      Value: !Ref ApiGatewayResourceBookables
+      Export:
+        Name: ${self:custom.stage}-ExtApiGatewayResourceBookables

--- a/services/parameterStore/envs/example.bookablesEnvs.json
+++ b/services/parameterStore/envs/example.bookablesEnvs.json
@@ -1,0 +1,10 @@
+{
+  "bookables": [
+    {
+      "name": "Test tjänst", 
+      "sharedMailbox": "test@helsingborg.se", 
+      "address": "Drottninggatan 2, Helsingborg", 
+      "formId": "xxxx"
+    }
+  ]
+}


### PR DESCRIPTION
## What was solved
Adding "bookables" as a new API Gateway resource path which should be used when using the bookables-api service.

## How was it solved
Created a new serverless stack called bookables-gateway-resource which creates the new api gateway resource and adds it to the root api gateway.

## Why was it solved in this way
This is the agreed way of creating Api Gateway resources for the root Api Gateway.

## How was it tested
Tested by first deploying the root Api Gateway (gateway-root) serverless stack. Checked the Api Gateway console and verified that the new resource was attached to the root gateway. 