### PR TITLE
feat: add new ssm envs parameter for booking service

### DIFF
--- a/services/parameterStore/envs/example.datatorgetEnvs.json
+++ b/services/parameterStore/envs/example.datatorgetEnvs.json
@@ -1,0 +1,4 @@
+{
+  "datatorgetEndpoint": "datatorget_endpoint",
+  "apiKey": "datatorget_api_key"
+}


### PR DESCRIPTION
# What was solved
Created a new SSM parameter for the booking service which is going to replace the old once used.
    1. bookingEnvs
    2. searchEnvs
    3. timeSlotsEnvs

# How was it solved
Solved it by adding a new SSM parameter called datatorgetEnvs

# Why was it solved in this way
Since the other 3 SSM parameter listed above almost have the same endpoint value (and same api key), and to simplify the change to the new datatorget  outlook endpoint in the future, the refactoring is done.

# How was it tested
Tested by deploying the SSM envs value in my AWS sandbox environment.