### PR TITLE
Feat: add email index to users table

### DIFF
--- a/services/dynamos/users/serverless.yml
+++ b/services/dynamos/users/serverless.yml
@@ -18,6 +18,8 @@ resources:
         AttributeDefinitions:
           - AttributeName: personalNumber
             AttributeType: S
+          - AttributeName: email
+            AttributeType: S
         KeySchema:
           - AttributeName: personalNumber
             KeyType: HASH
@@ -26,6 +28,15 @@ resources:
           KMSMasterKeyId: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/external/master
           SSEEnabled: true
           SSEType: KMS
+        GlobalSecondaryIndexes:
+        - IndexName: email-index
+          KeySchema:
+            - AttributeName: email
+              KeyType: HASH
+          Projection:
+            NonKeyAttributes:
+            - uuid
+            ProjectionType: 'INCLUDE'
 
   Outputs:
     UsersTableArn:
@@ -35,3 +46,9 @@ resources:
           - Arn
       Export:
         Name: ${self:custom.stage}-UsersTableArn
+
+    UsersTableAllIndexArn:
+      Value:
+        Fn::Join: ['/', ['Fn::GetAtt': [ UsersTable, Arn ], 'index', '*']]
+      Export:
+        Name: ${self:custom.stage}-UsersTableAllIndexArn


### PR DESCRIPTION
## Explain the changes you’ve made

I have added a GSI for email to users table. This index only includes the primary key and the UUID.

## Explain why these changes are made

This index was added for use with the new endpoint for fetching reference code. Using email as an index, we can query the user table without having to scan it, which is much faster and cheaper. We only need the UUID for the reference code so we are only projecting UUID.

## Explain your solution

I have added email as an attribute and created a GSI from that.

## Testing

In order to confirm that the change didn't break existing users, I deployed the old version of the users dynamo to my sandbox environment, and then deployed the GSI changes. It seems to have worked without any problems.

## Notes

We probably need to discuss whether we want to only project the UUID or all attributes, depending on whether we will need to index users by email in the future in order to retrieve more of the user data. This is important since the projection can't be changed without removing and re-deploying the users table (and by extension all services that interact with it).
