### PR TITLE
Script for synchronising SSM Parameters between environments

### DIFF
--- a/scripts/copy-aws-secrets.sh
+++ b/scripts/copy-aws-secrets.sh
@@ -1,8 +1,26 @@
 
-#!/bin/zsh
-DIR=${0:a:h}
-
+#!/bin/bash
+DIR=$(dirname $0)
 OUTPUT=/tmp/secrets.txt
+
+if [ -z ${AWS_VAULT} ]; then
+    echo AWS Vault needs to be installed to run this script.
+    exit 1
+fi
+
+which aws >/dev/null 2>&1
+
+if [ $? -ne 0 ]; then
+    echo AWS CLI needs to be installed to run this script.
+    exit 1
+fi
+
+which jq >/dev/null 2>&1
+
+if [ $? -ne 0 ]; then
+    echo The JQ tool needs to be installed to run this script.
+    exit 1
+fi
 
 clear
 echo This script extracts AWS Secrets from an AWS account and

--- a/scripts/copy-aws-secrets.sh
+++ b/scripts/copy-aws-secrets.sh
@@ -1,0 +1,37 @@
+
+#!/bin/zsh
+DIR=${0:a:h}
+
+OUTPUT=/tmp/secrets.txt
+
+clear
+echo This script extracts AWS Secrets from an AWS account and
+echo creates a file with the commands for recreating them in another.
+echo Before running, make sure that you are logged on to the account
+echo of which secrets you want to extract.
+echo
+echo The currently active source account is \"${AWS_VAULT:Unknown}\"
+echo
+read -p "Type C to continue: " CHOICE
+
+if [ "${CHOICE}" != "C" ]; then
+    exit 1
+fi
+
+LIST=`aws secretsmanager list-secrets --query "SecretList[*].Name" --output json`
+ 
+>${OUTPUT}
+for LINE in `jq -r ".[]" <<< ${LIST}`; do 
+    VALUE=`aws secretsmanager get-secret-value \
+        --secret-id "${LINE}" \
+        --query "SecretString" \
+        --output text`
+    echo aws secretsmanager create-secret --name ${LINE} --secret-string \'${VALUE}\' >>${OUTPUT}
+    echo >>${OUTPUT}
+done
+
+echo
+echo The extraction has finished. Logon to the destination account using aws-vault exec \<account\>
+echo and issue the commands from the file \"${OUTPUT}\" to complete the copy.
+echo 
+

--- a/scripts/copy-db-forms.sh
+++ b/scripts/copy-db-forms.sh
@@ -1,0 +1,29 @@
+
+#!/bin/zsh
+DIR=${0:a:h}
+
+OUTPUT=/tmp/forms.txt
+TABLE=dev-forms
+
+clear
+echo This script extracts Items from the ${TABLE} dynamo db table on an AWS account
+echo creates a file with the commands for recreating them in another.
+echo Before running, make sure that you are logged on to the account
+echo of which database you want to extract from.
+echo
+echo The currently active source account is \"${AWS_VAULT:Unknown}\"
+echo
+read -p "Type C to continue: " CHOICE
+
+if [ "${CHOICE}" != "C" ]; then
+    exit 1
+fi
+
+ITEMS=`aws dynamodb scan --table-name ${TABLE} --output json`
+jq -r '.Items[] | "aws dynamodb put-item --table-name '${TABLE}' --item '\''\(.)'\''\n\n"' <<< $ITEMS > ${OUTPUT}
+
+echo
+echo The extraction has finished. Logon to the destination account using aws-vault exec \<account\>
+echo and issue the commands from the file \"${OUTPUT}\" to complete the copy.
+echo 
+

--- a/scripts/copy-db-table.sh
+++ b/scripts/copy-db-table.sh
@@ -2,12 +2,25 @@
 #!/bin/zsh
 DIR=${0:a:h}
 
-OUTPUT=/tmp/forms.txt
 TABLE=dev-forms
 
+while [ "$1" != "" ]; do
+    case $1 in
+        -t | --table )
+            shift
+            TABLE=$1
+        ;;
+        *)      
+            exit 1
+    esac
+    shift
+done
+
+OUTPUT=/tmp/${TABLE}.txt
+
 clear
-echo This script extracts Items from the ${TABLE} dynamo db table on an AWS account
-echo creates a file with the commands for recreating them in another.
+echo This script extracts Items from the ${TABLE} dynamo db table of an
+echo  AWS account and creates a file with the commands for recreating them in another.
 echo Before running, make sure that you are logged on to the account
 echo of which database you want to extract from.
 echo

--- a/scripts/copy-db-table.sh
+++ b/scripts/copy-db-table.sh
@@ -1,22 +1,44 @@
 
-#!/bin/zsh
-DIR=${0:a:h}
-
+#!/bin/bash
+DIR=$(dirname $0)
 TABLE=dev-forms
 
-while [ "$1" != "" ]; do
-    case $1 in
+while [[ $# -gt 1 ]]
+do
+    key="$1"
+    case $key in
         -t | --table )
-            shift
-            TABLE=$1
+        TABLE="$2"
+        shift
         ;;
-        *)      
-            exit 1
+        *)
+        echo "Use --table <table-name> to specify which table to copy"
+        exit 1
+        ;;
     esac
     shift
 done
 
 OUTPUT=/tmp/${TABLE}.txt
+
+if [ -z ${AWS_VAULT} ]; then
+    echo AWS Vault needs to be installed to run this script.
+    exit 1
+fi
+
+which aws >/dev/null 2>&1
+
+if [ $? -ne 0 ]; then
+    echo AWS CLI needs to be installed to run this script.
+    exit 1
+fi
+
+which jq >/dev/null 2>&1
+
+if [ $? -ne 0 ]; then
+    echo The JQ tool needs to be installed to run this script.
+    exit 1
+fi
 
 clear
 echo This script extracts Items from the ${TABLE} dynamo db table of an

--- a/scripts/copy-ssm-parameters.sh
+++ b/scripts/copy-ssm-parameters.sh
@@ -1,8 +1,19 @@
 
-#!/bin/zsh
-DIR=${0:a:h}
-
+#!/bin/bash
+DIR=$(dirname $0)
 OUTPUT=/tmp/parameters.txt
+
+if [ -z ${AWS_VAULT} ]; then
+    echo AWS Vault needs to be installed to run this script.
+    exit 1
+fi
+
+which aws >/dev/null 2>&1
+
+if [ $? -ne 0 ]; then
+    echo AWS CLI needs to be installed to run this script.
+    exit 1
+fi
 
 clear
 echo This script extracts AWS SSM Parameters from an AWS account and

--- a/scripts/copy-ssm-parameters.sh
+++ b/scripts/copy-ssm-parameters.sh
@@ -1,0 +1,34 @@
+
+#!/bin/zsh
+DIR=${0:a:h}
+
+OUTPUT=/tmp/parameters.txt
+
+clear
+echo This script extracts AWS SSM Parameters from an AWS account and
+echo creates a file with the commands for recreating them in another.
+echo Before running, make sure that you are logged on to the account
+echo of which parameters you want to extract.
+echo
+echo The currently active source account is \"${AWS_VAULT:Unknown}\"
+echo
+read -p "Type C to continue: " CHOICE
+
+if [ "${CHOICE}" != "C" ]; then
+    exit 1
+fi
+
+JSON=`aws ssm get-parameters-by-path \
+        --path "/" \
+        --recursive \
+        --with-decryption \
+        --query "Parameters[*].{Name:Name,Value:Value,Type:Type}" \
+        --output json`
+
+jq -r '.[] | @sh "aws ssm put-parameter --name \(.Name) --type \(.Type) --value \(.Value)\n\n"' <<< $JSON >${OUTPUT}
+
+echo
+echo The extraction has finished. Logon to the destination account using aws-vault exec \<account\>
+echo and issue the commands from the file \"${OUTPUT}\" to complete the copy.
+echo 
+


### PR DESCRIPTION
A script to help synchronise sandbox with the SSM Parameters defined in another environment:

This script extracts AWS SSM Parameters from an AWS account and
creates a file with the commands for recreating them in another.
Before running, make sure that you are logged on to the account
of which parameters you want to extract.

The currently active source account is "mitt-hbg-dev"

Type C to continue: C

The extraction has finished. Logon to the destination account using aws-vault exec <account>
and issue the commands from the file /tmp/parameters.txt to complete the copy.