### PR TITLE
feat: add status as api gateway path resource

### DIFF
--- a/services/gateway/resources/status/serverless.yml
+++ b/services/gateway/resources/status/serverless.yml
@@ -1,0 +1,37 @@
+service: status-gateway-resource
+
+custom: ${file(../../../../serverless.common.yml):custom}
+
+provider:
+  name: aws
+  runtime: nodejs14.x
+  stage: dev
+  region: eu-north-1
+  tracing:
+    apiGateway: true
+
+  apiGateway:
+    restApiId:
+      "Fn::ImportValue": ${self:custom.stage}-ExtApiGatewayRestApiId
+    restApiRootResourceId:
+      "Fn::ImportValue": ${self:custom.stage}-ExtApiGatewayRestApiRootResourceId
+
+  environment:
+    stage: ${self:custom.stage}
+    resourcesStage: ${self:custom.resourcesStage}
+
+resources:
+  Resources:
+    ApiGatewayResourceStatus:
+      Type: AWS::ApiGateway::Resource
+      Properties:
+        RestApiId: ${self:provider.apiGateway.restApiId}
+        ParentId: ${self:provider.apiGateway.restApiRootResourceId}
+        PathPart: status
+
+  Outputs:
+    ApiGatewayResourceStatus:
+      Value:
+        Ref: ApiGatewayResourceStatus
+      Export:
+        Name: ${self:custom.stage}-ExtApiGatewayResourceStatus


### PR DESCRIPTION
## What was solved
Added new api gateway path resource to enable fetching api status messages

## How was it solved
Created new serverless stack which creates the new path resource to the root api gateway. 

## Why was it solved in this way
This is how its done with other api gateway path resources

## How was it tested
Tested it by deploying it and checking the result in api gateway console.