### PR TITLE
feat: add version as root api gateway path

### DIFF
--- a/services/gateway/resources/version/serverless.yml
+++ b/services/gateway/resources/version/serverless.yml
@@ -1,0 +1,37 @@
+service: version-gateway-resource
+
+custom: ${file(../../../../serverless.common.yml):custom}
+
+provider:
+  name: aws
+  runtime: nodejs14.x
+  stage: dev
+  region: eu-north-1
+  tracing:
+    apiGateway: true
+
+  apiGateway:
+    restApiId:
+      "Fn::ImportValue": ${self:custom.stage}-ExtApiGatewayRestApiId
+    restApiRootResourceId:
+      "Fn::ImportValue": ${self:custom.stage}-ExtApiGatewayRestApiRootResourceId
+
+  environment:
+    stage: ${self:custom.stage}
+    resourcesStage: ${self:custom.resourcesStage}
+
+resources:
+  Resources:
+    ApiGatewayResourceVersion:
+      Type: AWS::ApiGateway::Resource
+      Properties:
+        RestApiId: ${self:provider.apiGateway.restApiId}
+        ParentId: ${self:provider.apiGateway.restApiRootResourceId}
+        PathPart: version
+
+  Outputs:
+    ApiGatewayResourceVersion:
+      Value:
+        Ref: ApiGatewayResourceVersion
+      Export:
+        Name: ${self:custom.stage}-ExtApiGatewayResourceVersion


### PR DESCRIPTION
## What was solved
Added new api gateway path resource to enable fetching application versions data

## How was it solved
Created new serverless stack which creates the new path resource to the root api gateway. 

## Why was it solved in this way
This is how its done with other api gateway path resources

## How was it tested
Tested it by deploying it and checking the result in api gateway console.