### PR TITLE
feat: create eviva queue resources

### DIFF
--- a/services/queues/viva/serverless.yml
+++ b/services/queues/viva/serverless.yml
@@ -52,9 +52,6 @@ resources:
 
   Outputs:
     VivaSubmissionQueueArn:
-      Value:
-        Fn::GetAtt:
-          - VivaSubmissionQueue
-          - Arn
+      Value: !GetAtt VivaSubmissionQueue.Arn
       Export:
-        Name: ${self:custom.stage}-VivaSubmissionQueue
+        Name: ${self:custom.stage}-VivaSubmissionQueueArn

--- a/services/queues/viva/serverless.yml
+++ b/services/queues/viva/serverless.yml
@@ -1,0 +1,60 @@
+service: queues-viva
+
+custom: ${file(../../../serverless.common.yml):custom}
+
+provider:
+  name: aws
+  stage: dev
+  region: eu-north-1
+
+resources:
+  Resources:
+    VivaSubmissionQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:custom.resourcesStage}-VivaSubmissionQueue
+
+    EventBridgeToVivaQueuePolicy:
+      Type: AWS::SQS::QueuePolicy
+      Properties:
+        PolicyDocument:
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service: events.amazonaws.com
+              Action: SQS:SendMessage
+              Resource: !GetAtt VivaSubmissionQueue.Arn
+        Queues:
+          - Ref: VivaSubmissionQueue
+
+    PostToVivaQueue:
+      Type: "AWS::Events::Rule"
+      Properties:
+        Targets:
+          - Arn: !GetAtt VivaSubmissionQueue.Arn
+            Id: "VivaSubmissionQueue"
+        EventPattern:
+          source:
+            - cases.database
+          detail-type:
+            - MODIFY
+          detail:
+            dynamodb:
+              NewImage:
+                provider:
+                  S: ["VIVA"]
+                status:
+                  M:
+                    type:
+                      S: [{ "prefix": "active:submitted" }]
+                state:
+                  S: ["PDF_GENERATED"]
+
+  Outputs:
+    VivaSubmissionQueueArn:
+      Value:
+        Fn::GetAtt:
+          - VivaSubmissionQueue
+          - Arn
+      Export:
+        Name: ${self:custom.stage}-VivaSubmissionQueue

--- a/services/queues/viva/serverless.yml
+++ b/services/queues/viva/serverless.yml
@@ -13,6 +13,7 @@ resources:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: ${self:custom.resourcesStage}-VivaSubmissionQueue
+        VisibilityTimeout: 120
 
     EventBridgeToVivaQueuePolicy:
       Type: AWS::SQS::QueuePolicy


### PR DESCRIPTION
## Purpose
When sending an application to Viva, the request sometimes fails due to instability. To work around this shortcoming and avoid manual labour to correct applications, each application is added to an SQS queue when the state has reached PDF_GENERATED. The queue has a lambda trigger that executes submitApplication on regular basis until the application has been successfully submitted.

install by issuing:

```
# checkout PR to GitHub library
cd services/queues/viva
sls deploy
```