### PR TITLE
fix: add cors headers for authorizer

### DIFF
--- a/services/gateway/root/serverless.yml
+++ b/services/gateway/root/serverless.yml
@@ -3,7 +3,6 @@ projectDir: ../../../
 
 plugins:
   - serverless-bundle
-  - serverless-offline
 
 custom: ${file(../../../serverless.common.yml):custom}
 
@@ -97,15 +96,24 @@ resources:
         Scope: REGIONAL
         IPAddressVersion: IPV4
         Addresses:
-          - 1.2.1.1/32  # Example ip.
-
+          - 1.2.1.1/32 # Example ip.
 
     WAFv2WebACLAssociation:
       DependsOn: 'ApiGatewayDeployment${sls:instanceId}'
       Type: AWS::WAFv2::WebACLAssociation
-      Properties: 
-        ResourceArn:  !Sub "arn:aws:apigateway:${self:provider.region}::/restapis/${ApiGatewayRestApi}/stages/${self:custom.stage}"
+      Properties:
+        ResourceArn: !Sub 'arn:aws:apigateway:${self:provider.region}::/restapis/${ApiGatewayRestApi}/stages/${self:custom.stage}'
         WebACLArn: !GetAtt WAFv2WebACL.Arn
+
+    GatewayResponseDefault4XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Credentials: "'true'"
+        ResponseType: DEFAULT_4XX
+        RestApiId:
+          Ref: 'ApiGatewayRestApi'
 
   Outputs:
     ApiGatewayRestApiId:


### PR DESCRIPTION
When a request has been denied by our custom authorizer, cors headers are not
returned in the response-headers. The consequence is that fetch in a browser will fail instead of
returning a proper 401.

This fix will add the headers on API gateway level.

To test:
Call the users-api with an invalid bearer token:
{{BaseUrl}}/users/me

Verify that the response headers contains:
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true

