### PR TITLE
fix:add dead letter queue on vivasubmission queue

### DIFF
--- a/services/queues/viva/serverless.yml
+++ b/services/queues/viva/serverless.yml
@@ -9,10 +9,36 @@ provider:
 
 resources:
   Resources:
+    VivaSubmissionDeadLetterQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:custom.resourcesStage}-VivaSubmissionDeadLetterQueue
+        MessageRetentionPeriod: 1209600  # 14 days
+        RedriveAllowPolicy: 
+          redrivePermission: byQueue
+          sourceQueueArns:
+            - !Sub arn:aws:sqs:${self:provider.region}:${AWS::AccountId}:${self:custom.stage}-VivaSubmissionQueue
+
+    VivaSubmissionToVivaDeadLetterQueuePolicy:
+      Type: AWS::SQS::QueuePolicy
+      Properties:
+        PolicyDocument:
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service: sqs.amazonaws.com
+              Action: SQS:SendMessage
+              Resource: !Sub arn:aws:sqs:${self:provider.region}:${AWS::AccountId}:${self:custom.stage}-VivaSubmissionQueue
+        Queues:
+          - !Ref VivaSubmissionDeadLetterQueue
+
     VivaSubmissionQueue:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: ${self:custom.resourcesStage}-VivaSubmissionQueue
+        RedrivePolicy:
+          deadLetterTargetArn: !GetAtt VivaSubmissionDeadLetterQueue.Arn
+          maxReceiveCount: 10
         VisibilityTimeout: 120
 
     EventBridgeToVivaQueuePolicy:


### PR DESCRIPTION
**What was done**
Added dead-letter-queue for easier troubleshooting of failed messages in `submitApplication` lambda

**How was it done**
Added a new queue and connected it on the original `VivaSubmission` queue. Added a max retry property which is set to 10, and after that messages are sent to the dead-letter-queue. Messages will be in the dead-letter-queue for maximum of 14 days before they are deleted.

**Why was it done in this way**
Today messages will stay in the original queue for a maximum of 4 days. Failed delivered messages will be in the same queue as new incoming ones. This makes it hard to find and troubleshoot a failed message. If failed messages were put in a dead-letter-queue, they would be much easier to handle, hence creating the queue.

**How was it tested**
Tested by deploying the dead-letter-queue on my own sandbox environment and put a failing message in the original queue. After the specified retries, the message would appear in the dead-letter-queue.