### PR TITLE
Feat/dead letter queue alarm

### DIFF
--- a/services/queues/viva/serverless.yml
+++ b/services/queues/viva/serverless.yml
@@ -77,6 +77,33 @@ resources:
                 state:
                   S: ["PDF_GENERATED"]
 
+    AlarmTopic:
+      Type: AWS::SNS::Topic
+      Properties: 
+        Subscription:
+          - Endpoint: 5b8c9a67.helsingborg.se@emea.teams.ms
+            Protocol: email
+
+    QueueDepthAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmDescription: "Alarm if queue depth grows beyond 1 messages"
+        Namespace: "AWS/SQS"
+        MetricName: ApproximateNumberOfMessagesVisible
+        Dimensions:
+          - Name: QueueName
+            Value: !GetAtt VivaSubmissionDeadLetterQueue.QueueName
+        Statistic: Sum
+        Period: 300
+        EvaluationPeriods: 1
+        Threshold: 1
+        ComparisonOperator: GreaterThanThreshold
+        AlarmActions:
+          - Ref: AlarmTopic
+        InsufficientDataActions:
+          - Ref: AlarmTopic
+
+
   Outputs:
     VivaSubmissionQueueArn:
       Value: !GetAtt VivaSubmissionQueue.Arn

--- a/services/queues/viva/serverless.yml
+++ b/services/queues/viva/serverless.yml
@@ -77,12 +77,8 @@ resources:
                 state:
                   S: ["PDF_GENERATED"]
 
-    AlarmTopic:
+    DeadLetterQueueAlarmTopic:
       Type: AWS::SNS::Topic
-      Properties: 
-        Subscription:
-          - Endpoint: 5b8c9a67.helsingborg.se@emea.teams.ms
-            Protocol: email
 
     QueueDepthAlarm:
       Type: AWS::CloudWatch::Alarm
@@ -96,13 +92,10 @@ resources:
         Statistic: Sum
         Period: 300
         EvaluationPeriods: 1
-        Threshold: 1
+        Threshold: 0
         ComparisonOperator: GreaterThanThreshold
         AlarmActions:
-          - Ref: AlarmTopic
-        InsufficientDataActions:
-          - Ref: AlarmTopic
-
+          - Ref: DeadLetterQueueAlarmTopic
 
   Outputs:
     VivaSubmissionQueueArn:


### PR DESCRIPTION
**What was done**
Created an alarm and a topic to send to whenever the dead-letter queue for vivasubmission queue contains at least one message

**How was it done**
Added the alarm and topic in the serverless.yaml file

**Why was it done in this way**
This is how alarms and topics are created with serverless/cloudformation templates
