### PR TITLE
feat(copyattachment): enable eventbridge events on bucket

### DIFF
--- a/services/storage/attachments/serverless.yml
+++ b/services/storage/attachments/serverless.yml
@@ -47,6 +47,9 @@ resources:
             - Id: 'expire-all-rule'
               Status: Enabled
               ExpirationInDays: 3
+        NotificationConfiguration:
+          EventBridgeConfiguration: 
+            EventBridgeEnabled: true
 
   Outputs:
     AttachmentsBucketArn:
@@ -59,6 +62,5 @@ resources:
 
     AttachmentsBucketName:
       Value: !Ref AttachmentsBucketArn
-
       Export:
         Name: ${self:custom.stage}-AttachmentsBucketName


### PR DESCRIPTION
**What was done**
Enable EventBridge events on Attachments bucket to be able to act on put events to be able to copy objects

**How was it done**
Added a notification configuration on the bucket which enables the eventbridge events

**How was it tested**
Deployed and tested the changes in a sandbox environment 