### PR TITLE
Feat/enable sqs sse encryption

### DIFF
--- a/services/queues/viva/serverless.yml
+++ b/services/queues/viva/serverless.yml
@@ -15,6 +15,7 @@ resources:
       Properties:
         QueueName: ${self:custom.resourcesStage}-EventBridgeDeadLetterQueue
         MessageRetentionPeriod: 345600  # 4 days
+        KmsMasterKeyId: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/external/master
 
     EventBridgeToDeadLetterQueuePolicy:
       Type: AWS::SQS::QueuePolicy
@@ -38,6 +39,7 @@ resources:
           redrivePermission: byQueue
           sourceQueueArns:
             - !Sub arn:aws:sqs:${self:provider.region}:${AWS::AccountId}:${self:custom.stage}-VivaSubmissionQueue
+        KmsMasterKeyId: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/external/master
 
     VivaSubmissionToVivaDeadLetterQueuePolicy:
       Type: AWS::SQS::QueuePolicy
@@ -60,6 +62,7 @@ resources:
           deadLetterTargetArn: !GetAtt VivaSubmissionDeadLetterQueue.Arn
           maxReceiveCount: 10
         VisibilityTimeout: 120
+        KmsMasterKeyId: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/external/master
 
     EventBridgeToVivaQueuePolicy:
       Type: AWS::SQS::QueuePolicy


### PR DESCRIPTION
**What was done**
Enable SSE encryption with KMS customer key on SQS

**How was it done**
Added the `KmsMasterKeyId` on sqs with the value of our customer master key on KMS. This enables the SSE encryption on SQS. 

**How was it tested**
This PR is dependent on https://github.com/helsingborg-stad/helsingborg-io-sls-resources/pull/117 for updating the customer KMS key policy for enabling AWS EventBridge for using the key.

Once the key is updated, simply deploy the SQS queues and check the result in the SQS console. Encryption should be enabled with the customer provided KMS key.