### PR TITLE
fix: correct glob pattern for ssm envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,5 @@ env.yml
 .vscode
 .dccache
 
-[!example.]*.json
+services/parameterStore/envs/*.json
+!services/parameterStore/envs/example.*.json


### PR DESCRIPTION
Fixed glob pattern used for `.gitignore` and `ssmPutParameter.sh`.