### PR TITLE
fix(serverless.yml): fix public access block configuration

### DIFF
--- a/services/storage/attachments/serverless.yml
+++ b/services/storage/attachments/serverless.yml
@@ -30,7 +30,12 @@ resources:
                 SSEAlgorithm: 'aws:kms'
                 KMSMasterKeyID: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/external/master
               BucketKeyEnabled: true
-        AccessControl: PublicRead
+        AccessControl: Private
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: false
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true
         CorsConfiguration:
           CorsRules:
             - AllowedMethods:


### PR DESCRIPTION
**What was done**
Fix block configuration on attachment bucket

**How was it done**
By changing the bucket configuration in the cloudformation template

**How was it tested**
Deployed the changes in my sandbox environment and fulfilled a grundansökan form and checked that every attachment were sent to viva successfully.